### PR TITLE
[style] 설문리스트 Page UI

### DIFF
--- a/src/components/SurveyList/SurveyList.tsx
+++ b/src/components/SurveyList/SurveyList.tsx
@@ -1,0 +1,96 @@
+import styled from 'styled-components';
+
+const data = [
+  {
+    title: '스마트ICT융합공학과 종합설계1 팀프로젝트 수요조사',
+    link: 'https://docs.google.com/forms/',
+  },
+  {
+    title: '스마트ICT융합공학과 종합설계1 팀프로젝트 수요조사',
+    link: 'https://docs.google.com/forms/',
+  },
+  {
+    title: '스마트ICT융합공학과 종합설계1 팀프로젝트 수요조사',
+    link: 'https://docs.google.com/forms/',
+  },
+  {
+    title: '스마트ICT융합공학과 종합설계1 팀프로젝트 수요조사',
+    link: 'https://docs.google.com/forms/',
+  },
+];
+
+const SurveyList = () => {
+  return (
+    <SurveyListLayout>
+      <Label>LIST</Label>
+      <Title>설문조사 리스트</Title>
+      <SurveyListContainer>
+        {data.map((item, index) => (
+          <ListItem key={index}>
+            <p>{item.title}</p>
+            <p>
+              링크: <a href={item.link}>{item.link}</a>
+            </p>
+          </ListItem>
+        ))}
+      </SurveyListContainer>
+    </SurveyListLayout>
+  );
+};
+
+export default SurveyList;
+
+const SurveyListLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 6rem;
+  background-color: ${({ theme }) => theme.colors.white};
+  position: relative;
+`;
+
+const Label = styled.div`
+  ${({ theme }) => theme.fonts.body2};
+  border: 1px solid ${({ theme }) => theme.colors.lightgray};
+  border-radius: 5rem;
+  padding: 0.1rem 1rem;
+  position: absolute;
+  top: 6rem;
+  left: 6rem;
+`;
+
+const Title = styled.p`
+  ${({ theme }) => theme.fonts.heading1};
+  margin-top: 2rem;
+`;
+
+const SurveyListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding: 2rem 5rem;
+  gap: 1rem;
+`;
+
+const ListItem = styled.div`
+  width: 100%;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.black};
+  background-color: ${({ theme }) => theme.colors.blue1};
+  &:nth-child(odd) {
+    background-color: ${({ theme }) => theme.colors.blue1};
+  }
+  &:nth-child(even) {
+    background-color: ${({ theme }) => theme.colors.blue2};
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;

--- a/src/pages/SurveyListPage/SurveyListPage.tsx
+++ b/src/pages/SurveyListPage/SurveyListPage.tsx
@@ -1,7 +1,13 @@
+import SurveyList from '../../components/SurveyList/SurveyList';
+
 interface SurveyListPageProps {}
 
 const SurveyListPage = ({}: SurveyListPageProps) => {
-  return <div>설문 리스트</div>;
+  return (
+    <>
+      <SurveyList />
+    </>
+  );
 };
 
 export default SurveyListPage;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -14,6 +14,8 @@ const colors = {
   black: '#000000',
   lightgray: '#D3D3D3',
   darkgray: '#808080',
+  blue1: '#CDE8FF',
+  blue2: '#DFF3FF',
 };
 
 const fonts = {


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #15 

<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

설문 리스트 페이지를 구성하는 `SurveyList` 컴포넌트 구현
추후 get api 연결 예정

짝/홀 배경색 다르게 하는 스타일 적용
```
  background-color: ${({ theme }) => theme.colors.blue1};
  &:nth-child(odd) {
    background-color: ${({ theme }) => theme.colors.blue1};
  }
  &:nth-child(even) {
    background-color: ${({ theme }) => theme.colors.blue2};
  }
```


### 스크린샷 (선택)
<img width="1464" alt="스크린샷 2024-06-26 16 00 39" src="https://github.com/Sur-round/FE/assets/128016888/2bd66fe8-c501-4578-a630-ffc73fdce7fb">

